### PR TITLE
Fix nested form save behaviour

### DIFF
--- a/django_material_demo/polls/utils.py
+++ b/django_material_demo/polls/utils.py
@@ -20,27 +20,17 @@ def get_html_list(arr):
 
 
 class FormSetForm(ModelForm):
-    parent_instance_field = None
+    parent_instance_field = ''
 
     def __init__(self, parent_instance=None,
                  get_formset=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         self.parent_instance = parent_instance
         self.formset = get_formset and get_formset()
 
-        if not self.initial:
-            self.initial = {
-                self.parent_instance_field: self.parent_instance.pk}
-
     def save(self, commit):
-        model = self._meta.model
-        fields = self._meta.fields
-
-        kwargs = {k: self.cleaned_data.get(k) for k in fields}
-        kwargs[self.parent_instance_field] = self.parent_instance
-
-        return model.objects.create(**kwargs)
+        setattr(self.instance, self.parent_instance_field, self.parent_instance)
+        return super().save(commit)
 
     def full_clean(self):
         super().full_clean()


### PR DESCRIPTION
refs #7

This is a fix for https://github.com/oursky/django-material-demo/pull/31. Turns out things are not that complicated. We just need to assign the parent instance back, which is something I expect the library to do. I think it might be because of the different behaviour of newer django version.

I think in the long run, we will need to maintain the django-superform ourselves, and we would not require developers to fix the behaviour like we do in this PR.